### PR TITLE
pageAction changes to match browserAction

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ If you like to get an extension working fast, just follow the [chrome-scalajs-te
 Add this to your `project/plugins.sbt`:
 
 ```scala
-addSbtPlugin("com.alexitc" % "sbt-chrome-plugin" % "0.7.2")
+addSbtPlugin("com.alexitc" % "sbt-chrome-plugin" % "0.7.3")
 ```
 
 Add this to your project dependencies:
 
 ```scala
-"com.alexitc" %%% "scala-js-chrome" % "0.7.2"
+"com.alexitc" %%% "scala-js-chrome" % "0.7.3"
 ```
 
 If you need the latest version, clone the repository and run `sbt version` on it, replace the current version with that value.

--- a/sbt-plugin/src/main/scala/com/alexitc/JsonCodecs.scala
+++ b/sbt-plugin/src/main/scala/com/alexitc/JsonCodecs.scala
@@ -127,6 +127,17 @@ object JsonCodecs {
       )
     }
 
+  implicit val pageActionEncoder =
+    writer[ujson.Value].comap[chrome.PageAction] { pageAction =>
+      ujson.Obj(
+        ("default_title", writeJs(pageAction.title)),
+        ("default_popup", writeJs(pageAction.popup)),
+        ("default_icon", ujson.Obj.from(pageAction.icon.map {
+          case (k, v) => (k.toString, ujson.Str.apply(v))
+        }))
+      )
+    }
+
   implicit val optionUIEncoder = writer[ujson.Value].comap[chrome.OptionsUI] { optionUI =>
     ujson.Obj(
       ("page", ujson.Str.apply(optionUI.page)),
@@ -246,6 +257,7 @@ object JsonCodecs {
         ("omnibox", writeJs(manifest.omnibox)),
         ("options_ui", writeJs(manifest.optionsUI)),
         ("browser_action", writeJs(manifest.browserAction)),
+        ("page_action", writeJs(manifest.pageAction)),
         ("chrome_ui_overrides", writeJs(manifest.chromeUIOverrides)),
         ("chrome_url_overrides", writeJs(manifest.chromeUrlOverrides)),
         ("content_scripts", writeJs(manifest.contentScripts))

--- a/sbt-plugin/src/test/scala/com/alexitc/JsonCodecsSpec.scala
+++ b/sbt-plugin/src/test/scala/com/alexitc/JsonCodecsSpec.scala
@@ -2,7 +2,7 @@ package com.alexitc
 
 import chrome.permissions.Permission
 import chrome.permissions.Permission.API
-import chrome.{Background, BrowserAction, ContentScript, ExtensionManifest}
+import chrome.{Background, BrowserAction, ContentScript, ExtensionManifest, PageAction}
 import org.scalatest.matchers.must.Matchers._
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -11,7 +11,7 @@ class JsonCodecsSpec extends AnyWordSpec {
   import OptionPickler._
 
   "The extension manifest" should {
-    "ger rendered properly" in {
+    "get rendered properly with browser action" in {
       val expected =
         """
 {"manifest_version":2,"name":"__MSG_extensionName__","version":"1.0.0","default_locale":"en","description":"TO BE UPDATED","icons":{"48":"icons/48/app.png","96":"icons/96/app.png","128":"icons/128/app.png"},"web_accessible_resources":["icons/*"],"permissions":["storage","notifications","alarms"],"background":{"scripts":["scripts/common.js","dependencies.js","main.js","scripts/background-script.js"]},"browser_action":{"default_title":"TO BE DEFINED - POPUP TITLE","default_popup":"popup.html","default_icon":{"48":"icons/48/app.png","96":"icons/96/app.png","128":"icons/128/app.png"}},"content_scripts":[{"matches":["https://github.com/*"],"css":["css/active-tab.css"],"js":["scripts/common.js","dependencies.js","main.js","scripts/active-tab-script.js"]}]}
@@ -28,6 +28,54 @@ class JsonCodecsSpec extends AnyWordSpec {
         override val defaultLocale: Option[String] = Some("en")
         override val browserAction: Option[BrowserAction] = Some(
           BrowserAction(
+            icons,
+            Some("TO BE DEFINED - POPUP TITLE"),
+            Some("popup.html")
+          )
+        )
+
+        val commonScripts =
+          List("scripts/common.js", "dependencies.js", "main.js")
+
+        override val background = Background(
+          scripts = commonScripts ::: List("scripts/background-script.js")
+        )
+
+        override val contentScripts: List[ContentScript] = List(
+          ContentScript(
+            matches = List(
+              "https://github.com/*" // TODO: REPLACE ME
+            ),
+            css = List("css/active-tab.css"),
+            js = commonScripts ::: List("scripts/active-tab-script.js")
+          )
+        )
+
+        override val webAccessibleResources = List("icons/*")
+      }
+
+      val contentJson = writeJs(manifest).dropNullValues.getOrElse(ujson.Obj())
+      val result = write(contentJson)
+      result must be(expected)
+    }
+
+    "get rendered properly with page actions" in {
+      val expected =
+        """
+{"manifest_version":2,"name":"__MSG_extensionName__","version":"1.0.0","default_locale":"en","description":"TO BE UPDATED","icons":{"48":"icons/48/app.png","96":"icons/96/app.png","128":"icons/128/app.png"},"web_accessible_resources":["icons/*"],"permissions":["storage","notifications","alarms"],"background":{"scripts":["scripts/common.js","dependencies.js","main.js","scripts/background-script.js"]},"page_action":{"default_title":"TO BE DEFINED - POPUP TITLE","default_popup":"popup.html","default_icon":{"48":"icons/48/app.png","96":"icons/96/app.png","128":"icons/128/app.png"}},"content_scripts":[{"matches":["https://github.com/*"],"css":["css/active-tab.css"],"js":["scripts/common.js","dependencies.js","main.js","scripts/active-tab-script.js"]}]}
+""".stripMargin.trim
+
+      val manifest: chrome.Manifest = new ExtensionManifest {
+        override val name = "__MSG_extensionName__"
+        override val version = "1.0.0"
+        override val description = Some("TO BE UPDATED")
+        override val icons = Chrome.icons("icons", "app.png", Set(48, 96, 128))
+        override val permissions =
+          Set[Permission](API.Storage, API.Notifications, API.Alarms)
+
+        override val defaultLocale: Option[String] = Some("en")
+        override val pageAction: Option[PageAction] = Some(
+          PageAction(
             icons,
             Some("TO BE DEFINED - POPUP TITLE"),
             Some("popup.html")

--- a/shared/src/main/scala/chrome/Manifest.scala
+++ b/shared/src/main/scala/chrome/Manifest.scala
@@ -36,6 +36,12 @@ case class BrowserAction(
     popup: Option[String] = None
 )
 
+case class PageAction(
+    icon: Map[Int, String] = Map.empty,
+    title: Option[String] = None,
+    popup: Option[String] = None
+)
+
 case class ContentScript(matches: List[String], css: List[String], js: List[String])
 
 case class Bluetooth(
@@ -104,6 +110,7 @@ trait AppManifest extends chrome.Manifest {
 trait ExtensionManifest extends chrome.Manifest {
   val background: Background
   val browserAction: Option[BrowserAction] = None
+  val pageAction: Option[PageAction] = None
   val omnibox: Option[Omnibox] = None
   val optionsUI: Option[OptionsUI] = None
   val chromeUIOverrides: Option[ChromeUIOverrides] = None


### PR DESCRIPTION
- Adding a manifest entry for pageAction instead of browerAction. Doesn't have any smart error handling around having both of them, but the chrome loading will fail so I didn't think it was too necessary
- Also made the pageAction API use the same interface for the tab ids that gets returned from the Tabs API

Thanks @AlexITC 